### PR TITLE
Cron Type Cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 PUBLIC_BALANCE_DATA_URL=https://mcce-cdn.perny.dev/balances.json
 PUBLIC_TRANSACTIONS_DATA_URL=https://mcce-cdn.perny.dev/transactions.json
 
-# ------ 
+# ------
 # Required for the cron job, if using the data without fetching, you can ignore this
 CRON_SECRET=
 GCL_ACCOUNT_ID=

--- a/src/lib/conversion.ts
+++ b/src/lib/conversion.ts
@@ -6,5 +6,5 @@ export async function fetchSEKUSDRate() {
         throw new Error("Failed to fetch SEK/USD rate");
     }
     const data = await resp.json();
-    SEK_USD_RATE = data.rates.USD; 
+    SEK_USD_RATE = data.rates.USD;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,13 +10,6 @@ export interface Transaction {
 	valueDate?: string;
 }
 
-export interface APIAccountTransactions {
-	transactions: {
-		booked: Transaction[];
-		pending?: Transaction[];
-	};
-}
-
 export enum BalanceType {
 	INTERIM_AVAILABLE = 'interimAvailable',
 }
@@ -24,6 +17,13 @@ export enum BalanceType {
 export interface Balance {
 	balanceAmount: Amount;
 	balanceType: BalanceType;
+}
+
+export interface APIAccountTransactions {
+	transactions: {
+		booked: Transaction[];
+		pending?: Transaction[];
+	};
 }
 
 export interface APIAccountBalance {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,13 @@ export interface Transaction {
 	valueDate?: string;
 }
 
+export interface APIAccountTransactions {
+    transactions: {
+        booked: Transaction[];
+        pending?: Transaction[];
+    };
+}
+
 export enum BalanceType {
 	INTERIM_AVAILABLE = 'interimAvailable',
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,7 +6,7 @@ export interface Amount {
 export interface Transaction {
 	remittanceInformationUnstructured?: string;
 	creditorName?: string;
-	transactionAmount: Amount;
+	transactionAmount?: Amount;
 	valueDate?: string;
 }
 
@@ -27,7 +27,6 @@ export interface APIAccountTransactions {
 }
 
 export interface APIAccountBalance {
-	// lazy :-)
 	balances: object;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,7 +6,6 @@ export interface Amount {
 export interface Transaction {
 	remittanceInformationUnstructured?: string;
 	creditorName?: string;
-	// field is always present
 	transactionAmount: Amount;
 	valueDate?: string;
 }
@@ -25,4 +24,13 @@ export enum BalanceType {
 export interface Balance {
 	balanceAmount: Amount;
 	balanceType: BalanceType;
+}
+
+export interface APIAccountBalance {
+	// lazy :-)
+	balances: object;
+}
+
+export interface APIJWTToken {
+	access: string;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,7 +6,8 @@ export interface Amount {
 export interface Transaction {
 	remittanceInformationUnstructured?: string;
 	creditorName?: string;
-	transactionAmount?: Amount;
+	// field is always present
+	transactionAmount: Amount;
 	valueDate?: string;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,10 +12,10 @@ export interface Transaction {
 }
 
 export interface APIAccountTransactions {
-    transactions: {
-        booked: Transaction[];
-        pending?: Transaction[];
-    };
+	transactions: {
+		booked: Transaction[];
+		pending?: Transaction[];
+	};
 }
 
 export enum BalanceType {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import '../app.css';
 	import "@fontsource/jetbrains-mono";
-	
+
 	let { children } = $props();
 </script>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -147,7 +147,7 @@
 			</p>
 		</div>
 	</div>
-	
+
 	<h2 class="mb-2 mt-8 block text-xl font-bold" id="funding-left">Funding left</h2>
 	<div class="flex gap-4">
 		<span aria-labelledby="funding-left">

--- a/src/routes/cron/+server.ts
+++ b/src/routes/cron/+server.ts
@@ -3,98 +3,98 @@ import type { APIAccountTransactions, Transaction } from '$lib/types';
 import { json } from '@sveltejs/kit';
 
 export const POST = async ({ request }) => {
-    const cronToken = request.headers.get('x-cron-token');
-    // don't need to || '' cronToken;
-    // typeof env.CRON_SECRET is always a string, never null
-    if (cronToken !== env.CRON_SECRET) {
-        return new Response('Unauthorized', { status: 401 });
-    }
+	const cronToken = request.headers.get('x-cron-token');
+	// don't need to || '' cronToken;
+	// typeof env.CRON_SECRET is always a string, never null
+	if (cronToken !== env.CRON_SECRET) {
+		return new Response('Unauthorized', { status: 401 });
+	}
 
-    console.log('CRON JOB');
+	console.log('CRON JOB');
 
-    const token = await fetch('https://bankaccountdata.gocardless.com/api/v2/token/new/', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-            secret_id: env.GCL_SECRET_ID,
-            secret_key: env.GCL_SECRET_KEY
-        })
-    });
-    const bodyString = await token.text();
-    console.log(bodyString);
-    const body = JSON.parse(bodyString);
-    if (token.status !== 200) {
-        return new Response('Failed to get access token', { status: 401 });
-    }
-    const accessToken = body.access;
+	const token = await fetch('https://bankaccountdata.gocardless.com/api/v2/token/new/', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			secret_id: env.GCL_SECRET_ID,
+			secret_key: env.GCL_SECRET_KEY
+		})
+	});
+	const bodyString = await token.text();
+	console.log(bodyString);
+	const body = JSON.parse(bodyString);
+	if (token.status !== 200) {
+		return new Response('Failed to get access token', { status: 401 });
+	}
+	const accessToken = body.access;
 
-    console.log(env.GCL_ACCOUNT_ID);
+	console.log(env.GCL_ACCOUNT_ID);
 
-    const transactionsResp = await fetch(`https://bankaccountdata.gocardless.com/api/v2/accounts/${env.GCL_ACCOUNT_ID}/transactions/`, {
-        method: 'GET',
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${accessToken}`
-        }
-    });
-    const transactionsBody: APIAccountTransactions = await transactionsResp.json();
-    if (transactionsResp.status !== 200) {
-        console.log(transactionsBody);
-        return new Response('Failed to get transactions', { status: 500 });
-    }
-
-
-    // TODO: cleaner way to type this?
-    const allowedKeys = ['remittanceInformationUnstructured', 'creditorName', 'transactionAmount', 'valueDate'] as (keyof Transaction)[];
-
-    // filter out sensitive data
-    const bookedTransactions = transactionsBody.transactions.booked.map(t => {
-        console.log(t);
-
-        return Object.fromEntries(
-            // array of key-value pairs of allowed key and current transactions' corresponding value,
-            // then turn it back into an object (fromEntries)
-            allowedKeys.map(key => [key, t[key]])
-        );
-    });
+	const transactionsResp = await fetch(`https://bankaccountdata.gocardless.com/api/v2/accounts/${env.GCL_ACCOUNT_ID}/transactions/`, {
+		method: 'GET',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${accessToken}`
+		}
+	});
+	const transactionsBody: APIAccountTransactions = await transactionsResp.json();
+	if (transactionsResp.status !== 200) {
+		console.log(transactionsBody);
+		return new Response('Failed to get transactions', { status: 500 });
+	}
 
 
-    const s3 = new Bun.S3Client({
-        accessKeyId: env.AWS_ACCESS_KEY_ID,
-        secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
-        endpoint: env.AWS_ENDPOINT_URL_S3,
-        bucket: env.BUCKET_NAME
-    });
+	// TODO: cleaner way to type this?
+	const allowedKeys = ['remittanceInformationUnstructured', 'creditorName', 'transactionAmount', 'valueDate'] as (keyof Transaction)[];
 
-    const transactions = s3.file('transactions.json');
-    await Bun.write(transactions, JSON.stringify({
-        transactions: {
-            booked: bookedTransactions,
-            pending: transactionsBody.transactions.pending
-        }
-    }));
+	// filter out sensitive data
+	const bookedTransactions = transactionsBody.transactions.booked.map(t => {
+		console.log(t);
 
-    const balancesResp = await fetch(`https://bankaccountdata.gocardless.com/api/v2/accounts/${env.GCL_ACCOUNT_ID}/balances/`, {
-        method: 'GET',
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${accessToken}`
-        }
-    });
-    const balancesBody = await balancesResp.json();
-    if (balancesResp.status !== 200) {
-        console.log(balancesBody);
-        return new Response('Failed to get balances', { status: 500 });
-    }
+		return Object.fromEntries(
+			// array of key-value pairs of allowed key and current transactions' corresponding value,
+			// then turn it back into an object (fromEntries)
+			allowedKeys.map(key => [key, t[key]])
+		);
+	});
 
-    const balances = s3.file('balances.json');
-    await Bun.write(balances, JSON.stringify({
-        balances: balancesBody.balances
-    }));
 
-    return json({
-        message: 'ok'
-    });
+	const s3 = new Bun.S3Client({
+		accessKeyId: env.AWS_ACCESS_KEY_ID,
+		secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+		endpoint: env.AWS_ENDPOINT_URL_S3,
+		bucket: env.BUCKET_NAME
+	});
+
+	const transactions = s3.file('transactions.json');
+	await Bun.write(transactions, JSON.stringify({
+		transactions: {
+			booked: bookedTransactions,
+			pending: transactionsBody.transactions.pending
+		}
+	}));
+
+	const balancesResp = await fetch(`https://bankaccountdata.gocardless.com/api/v2/accounts/${env.GCL_ACCOUNT_ID}/balances/`, {
+		method: 'GET',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${accessToken}`
+		}
+	});
+	const balancesBody = await balancesResp.json();
+	if (balancesResp.status !== 200) {
+		console.log(balancesBody);
+		return new Response('Failed to get balances', { status: 500 });
+	}
+
+	const balances = s3.file('balances.json');
+	await Bun.write(balances, JSON.stringify({
+		balances: balancesBody.balances
+	}));
+
+	return json({
+		message: 'ok'
+	});
 };

--- a/src/routes/cron/+server.ts
+++ b/src/routes/cron/+server.ts
@@ -1,6 +1,6 @@
 import { env } from '$env/dynamic/private';
-import type { APIAccountBalance, APIAccountTransactions, APIJWTToken, Transaction } from '$lib/types';
 import { json } from '@sveltejs/kit';
+import type { APIAccountBalance, APIAccountTransactions, APIJWTToken, Transaction } from '$lib/types';
 
 export const POST = async ({ request }) => {
 	const cronToken = request.headers.get('x-cron-token');
@@ -25,9 +25,11 @@ export const POST = async ({ request }) => {
 
 	const body: APIJWTToken = await token.json();
 	console.log(JSON.stringify(body));
+
 	if (token.status !== 200) {
 		return new Response('Failed to get access token', { status: 401 });
 	}
+
 	const accessToken = body.access;
 
 	console.log(env.GCL_ACCOUNT_ID);
@@ -39,12 +41,12 @@ export const POST = async ({ request }) => {
 			Authorization: `Bearer ${accessToken}`
 		}
 	});
+
 	const transactionsBody: APIAccountTransactions = await transactionsResp.json();
 	if (transactionsResp.status !== 200) {
 		console.log(transactionsBody);
 		return new Response('Failed to get transactions', { status: 500 });
 	}
-
 
 	// TODO: cleaner way to type this?
 	const allowedKeys = ['remittanceInformationUnstructured', 'creditorName', 'transactionAmount', 'valueDate'] as (keyof Transaction)[];
@@ -83,6 +85,7 @@ export const POST = async ({ request }) => {
 			Authorization: `Bearer ${accessToken}`
 		}
 	});
+
 	const balancesBody: APIAccountBalance = await balancesResp.json();
 	if (balancesResp.status !== 200) {
 		console.log(balancesBody);

--- a/src/routes/cron/+server.ts
+++ b/src/routes/cron/+server.ts
@@ -4,13 +4,13 @@ import { json } from '@sveltejs/kit';
 
 export const POST = async ({ request }) => {
     const cronToken = request.headers.get('x-cron-token');
-    // don't need to || "" cronToken;
+    // don't need to || '' cronToken;
     // typeof env.CRON_SECRET is always a string, never null
     if (cronToken !== env.CRON_SECRET) {
         return new Response('Unauthorized', { status: 401 });
     }
 
-    console.log("CRON JOB");
+    console.log('CRON JOB');
 
     const token = await fetch('https://bankaccountdata.gocardless.com/api/v2/token/new/', {
         method: 'POST',
@@ -47,7 +47,7 @@ export const POST = async ({ request }) => {
 
 
     // TODO: cleaner way to type this?
-    const allowedKeys = ["remittanceInformationUnstructured", "creditorName", "transactionAmount", "valueDate"] as (keyof Transaction)[];
+    const allowedKeys = ['remittanceInformationUnstructured', 'creditorName', 'transactionAmount', 'valueDate'] as (keyof Transaction)[];
 
     // filter out sensitive data
     const bookedTransactions = transactionsBody.transactions.booked.map(t => {

--- a/src/routes/cron/+server.ts
+++ b/src/routes/cron/+server.ts
@@ -1,5 +1,5 @@
 import { env } from '$env/dynamic/private';
-import type { APIAccountTransactions, Transaction } from '$lib/types';
+import type { APIAccountBalance, APIAccountTransactions, APIJWTToken, Transaction } from '$lib/types';
 import { json } from '@sveltejs/kit';
 
 export const POST = async ({ request }) => {
@@ -22,9 +22,9 @@ export const POST = async ({ request }) => {
 			secret_key: env.GCL_SECRET_KEY
 		})
 	});
-	const bodyString = await token.text();
-	console.log(bodyString);
-	const body = JSON.parse(bodyString);
+
+	const body: APIJWTToken = await token.json();
+	console.log(JSON.stringify(body));
 	if (token.status !== 200) {
 		return new Response('Failed to get access token', { status: 401 });
 	}
@@ -83,7 +83,7 @@ export const POST = async ({ request }) => {
 			Authorization: `Bearer ${accessToken}`
 		}
 	});
-	const balancesBody = await balancesResp.json();
+	const balancesBody: APIAccountBalance = await balancesResp.json();
 	if (balancesResp.status !== 200) {
 		console.log(balancesBody);
 		return new Response('Failed to get balances', { status: 500 });

--- a/src/routes/cron/+server.ts
+++ b/src/routes/cron/+server.ts
@@ -4,8 +4,6 @@ import type { APIAccountBalance, APIAccountTransactions, APIJWTToken, Transactio
 
 export const POST = async ({ request }) => {
 	const cronToken = request.headers.get('x-cron-token');
-	// don't need to || '' cronToken;
-	// typeof env.CRON_SECRET is always a string, never null
 	if (cronToken !== env.CRON_SECRET) {
 		return new Response('Unauthorized', { status: 401 });
 	}

--- a/src/routes/cron/+server.ts
+++ b/src/routes/cron/+server.ts
@@ -1,5 +1,5 @@
 import { env } from '$env/dynamic/private';
-import type { Transaction } from '$lib/types';
+import type { APIAccountTransactions, Transaction } from '$lib/types';
 import { json } from '@sveltejs/kit';
 
 export const POST = async ({ request }) => {
@@ -39,7 +39,7 @@ export const POST = async ({ request }) => {
             Authorization: `Bearer ${accessToken}`
         }
     });
-    const transactionsBody: AccountTransactions = await transactionsResp.json();
+    const transactionsBody: APIAccountTransactions = await transactionsResp.json();
     if (transactionsResp.status !== 200) {
         console.log(transactionsBody);
         return new Response('Failed to get transactions', { status: 500 });
@@ -97,14 +97,4 @@ export const POST = async ({ request }) => {
     return json({
         message: 'ok'
     });
-};
-
-
-
-// simplified to relevant fields
-type AccountTransactions = {
-    transactions: {
-        booked: Transaction[];
-        pending?: Transaction[];
-    };
 };

--- a/src/routes/cron/+server.ts
+++ b/src/routes/cron/+server.ts
@@ -1,11 +1,12 @@
 import { env } from '$env/dynamic/private';
 import type { Transaction } from '$lib/types';
 import { json } from '@sveltejs/kit';
-import type { RequestHandler } from './$types';
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST = async ({ request }) => {
     const cronToken = request.headers.get('x-cron-token');
-    if ((cronToken || "") !== env.CRON_SECRET) {
+    // don't need to || "" cronToken;
+    // typeof env.CRON_SECRET is always a string, never null
+    if (cronToken !== env.CRON_SECRET) {
         return new Response('Unauthorized', { status: 401 });
     }
 
@@ -38,24 +39,27 @@ export const POST: RequestHandler = async ({ request }) => {
             Authorization: `Bearer ${accessToken}`
         }
     });
-    const transactionsBody = await transactionsResp.json();
+    const transactionsBody: AccountTransactions = await transactionsResp.json();
     if (transactionsResp.status !== 200) {
         console.log(transactionsBody);
         return new Response('Failed to get transactions', { status: 500 });
     }
 
+
+    // TODO: cleaner way to type this?
+    const allowedKeys = ["remittanceInformationUnstructured", "creditorName", "transactionAmount", "valueDate"] as (keyof Transaction)[];
+
     // filter out sensitive data
-    const bookedTransactions: Transaction[] = []
-    transactionsBody.transactions.booked.forEach(t => {
+    const bookedTransactions = transactionsBody.transactions.booked.map(t => {
         console.log(t);
-        bookedTransactions.push({
-            remittanceInformationUnstructured: t.remittanceInformationUnstructured,
-            creditorName: t.creditorName,
-            transactionAmount: t.transactionAmount,
-            valueDate: t.valueDate
-        });
-        return t;
+
+        return Object.fromEntries(
+            // array of key-value pairs of allowed key and current transactions' corresponding value,
+            // then turn it back into an object (fromEntries)
+            allowedKeys.map(key => [key, t[key]])
+        );
     });
+
 
     const s3 = new Bun.S3Client({
         accessKeyId: env.AWS_ACCESS_KEY_ID,
@@ -93,4 +97,14 @@ export const POST: RequestHandler = async ({ request }) => {
     return json({
         message: 'ok'
     });
+};
+
+
+
+// simplified to relevant fields
+type AccountTransactions = {
+    transactions: {
+        booked: Transaction[];
+        pending?: Transaction[];
+    };
 };

--- a/src/routes/cron/+server.ts
+++ b/src/routes/cron/+server.ts
@@ -6,7 +6,7 @@ import type { RequestHandler } from './$types';
 export const POST: RequestHandler = async ({ request }) => {
     const cronToken = request.headers.get('x-cron-token');
     if ((cronToken || "") !== env.CRON_SECRET) {
-        return new Response('Unauthorized', { status: 401 });   
+        return new Response('Unauthorized', { status: 401 });
     }
 
     console.log("CRON JOB");


### PR DESCRIPTION
I... realize I was supposed to create an issue before making a whole pull request, but I got a little ahead of myself :-)

The goal of this PR is to
- Fix the type error in `src/routes/cron/+server.ts` (line 40, `Parameter 't' implicitly has an 'any' type.`)
- Consistent formatting in the cron `+server.ts` file (single quotes, tabs instead of spaces, per the prettier config, and remove misc trailing spaces)
- Type all GoCardless calls as strongly as is necessary to avoid implicit `any` types

I tried to avoid any breaking change that I could, since I don't have a way to verify that I didn't completely break the cron job, and I don't want to completely change the project around without warning.

Other notes:
- The `transactionAmount` field in `Transaction` doesn't need to be optionally typed; the API docs indicate that the field is required. But I'm too cowardly to change it without passing it through you first
- The `balances` field in `APIAccountBalance` being typed as `object` is lazy, but practical
- I removed the `(cronToken || '')` check at the top of the method, since the type of `cronToken` is `string | null`, and `env.CRON_SECRET` is always a `string`. There should never be an overlap that makes the check necessary

In all, I tried to keep this PR pretty mild; though the diff does look intimidating, due to all spaces being replaced with tabs. It's very much a DX-focused PR, since I intend to follow up with more changes—if you're happy with this one. (Those changes will come with corresponding issues, hahaha.)